### PR TITLE
Add usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,36 @@ pnpm add futility-ui
 
 ## Usage
 
-WIP
+Install the library and include one of the provided style sheets.
+
+```bash
+pnpm add futility-ui
+```
+
+Import the styles in JavaScript:
+
+```javascript
+import 'futility-ui/styles.tailwind.css'; // or styles.base.css
+```
+
+Or from your main CSS file:
+
+```css
+@import 'futility-ui/styles.tailwind.css'; /* or styles.base.css */
+```
+
+Finally register the plugin in your Vue application:
+
+```javascript
+import { createApp } from 'vue';
+import FutilityUI from 'futility-ui';
+
+createApp(App)
+  .use(FutilityUI)
+  .mount('#app');
+```
+
+For details about choosing a stylesheet and other options, see the `usage` page in Storybook.
 
 
 ## Development

--- a/src/stories/usage.mdx
+++ b/src/stories/usage.mdx
@@ -1,0 +1,49 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Usage" />
+
+## Getting Started
+
+Install the package and decide how to include the stylesheet.
+
+```bash
+pnpm add futility-ui
+```
+
+### Importing the styles
+
+You can import the stylesheet from JavaScript:
+
+```javascript
+import 'futility-ui/styles.tailwind.css'; // or styles.base.css
+```
+
+or from your main CSS file:
+
+```css
+@import 'futility-ui/styles.tailwind.css'; /* or styles.base.css */
+```
+
+`styles.tailwind.css` bundles Tailwind\'s preflight together with the component theme.
+Choose `styles.base.css` if Tailwind is already configured in your project.
+
+### Using the components
+
+Install the whole library as a plugin:
+
+```javascript
+import { createApp } from 'vue';
+import FutilityUI from 'futility-ui';
+
+createApp(App)
+  .use(FutilityUI)
+  .mount('#app');
+```
+
+Alternatively import only the components you need:
+
+```javascript
+import { FButton, FInput } from 'futility-ui';
+```
+
+Now you can use the imported components in your templates.


### PR DESCRIPTION
## Summary
- document how to use the library and its stylesheets
- add a dedicated `usage` page in Storybook docs

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_688cc5c35f7c8321b7fce4130fa8191e